### PR TITLE
Fixing find config dir function

### DIFF
--- a/phpunit.plugin.zsh
+++ b/phpunit.plugin.zsh
@@ -50,7 +50,7 @@ __phpunit_project_dir() {
 
 __phpunit_config_dir() {
     local project_dir="${1:-$(__phpunit_project_dir)}";
-    local phpunit_config_file=$(find "$project_dir" -maxdepth 2 -name 'phpunit.xml*' -type f 2>/dev/null | head -n 1);
+    local phpunit_config_file=$(find "$project_dir" -maxdepth 2 -name 'phpunit.xml*' -type f -printf "%d %p\n" 2>/dev/null | sort -n | cut -d " " -f 2 | head -n 1);
     local phpunit_config_dir="${phpunit_config_file%/phpunit.xml*}";
 
     echo "$phpunit_config_dir";


### PR DESCRIPTION
By default, use the top most phpunit.xml we can find.

In my case I use intellij ide and inside my .idea directory I have a specific phpunit.xml. But by default the script use this one which is not intuitive.

So i sort by depth and take the closest one.

Eg: ./phpunit.xml will be used instead of .hidden_sub_dir/phpunit.xml